### PR TITLE
meson: don't use harfbuzz by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,5 +5,5 @@ option('bzip2', type: 'feature', value: 'auto',
   description: 'Use bzip2 to support bzip2-compressed fonts')
 option('zlib', type: 'feature', value: 'auto',
   description: 'Use system zlib instead of internal zlib')
-option('harfbuzz', type: 'feature', value: 'auto',
+option('harfbuzz', type: 'feature', value: 'disabled',
   description: 'Use HarfBuzz t improve auto-hinting of OpenType fonts')


### PR DESCRIPTION
Most Linux distro packages (at least Debian) seem to build
freetype without harfbuzz, so it can't be very important,
and it causes issues with circular dependencies (which
can be worked around, but the outcome might then be a
suboptimally-featured harfbuzz build).